### PR TITLE
Ajout des vues et templates relatives à la connexion et création de compte

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "widget_tweaks",
     "dsfr_holder",
     "secretariat",
 ]

--- a/secretariat/templates/registration/login.html
+++ b/secretariat/templates/registration/login.html
@@ -1,0 +1,125 @@
+{# see https://docs.djangoproject.com/en/4.2/topics/auth/default/#django.contrib.auth.views.LoginView #}
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+    <div class="fr-container">
+        <div class="fr-grid-row">
+            <div class="fr-col-lg-5">
+                {% if next %}
+                    {% if user.is_authenticated %}
+                        <p>
+                            Vous n'avez pas accès à cette page.
+                            Connectez-vous avec un compte muni des autorisations nécessaires.
+                        </p>
+                    {% else %}
+                        <p>Connectez-vous pour accéder à cette page.</p>
+                    {% endif %}
+                {% endif %}
+                <form id="login-1760" method="post">
+                    <input type="hidden" name="next" value="{{ next }}">
+                    {% csrf_token %}
+                    <fieldset class="fr-fieldset" id="login-1760-fieldset"
+                              aria-labelledby="login-1760-fieldset-legend login-1760-fieldset-messages">
+                        <legend class="fr-fieldset__legend" id="login-1760-fieldset-legend">
+                            <h2>Se connecter avec son compte</h2>
+                        </legend>
+                        <div class="fr-fieldset__element">
+                            <p class="fr-text--sm">
+                                Connectez-vous avec votre compte secrétariat.
+                                Bientôt vous pourrez vous connecter sans mot de passe !
+                            </p>
+                        </div>
+                        {% if form.errors %}
+                            <div class="fr-alert fr-alert--error">
+                                <p class="fr-alert__title">Une erreur s'est produite</p>
+                                {{ form.non_field_errors }}
+                            </div>
+                        {% endif %}
+                        <div class="fr-fieldset__element">
+                            <fieldset class="fr-fieldset" id="credentials" aria-labelledby="credentials-messages">
+                                <div class="fr-fieldset__element">
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="username-1757">
+                                            Adresse e-mail
+                                            <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
+                                        </label>
+                                        <input class="fr-input" autocomplete="username" aria-required="true"
+                                               aria-describedby="username-1757-messages" name="username"
+                                               id="username-1757"
+                                               type="text">
+                                        <div class="fr-messages-group" id="username-1757-messages"
+                                             aria-live="assertive">
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="fr-fieldset__element">
+                                    <div class="fr-password" id="password-1758">
+                                        <label class="fr-label" for="password-1758-input">
+                                            Mot de passe
+                                        </label>
+                                        <div class="fr-input-wrap">
+                                            <input class="fr-password__input fr-input"
+                                                   aria-describedby="password-1758-input-messages" aria-required="true"
+                                                   name="password" autocomplete="current-password"
+                                                   id="password-1758-input"
+                                                   type="password">
+                                        </div>
+                                        <div class="fr-messages-group" id="password-1758-input-messages"
+                                             aria-live="assertive">
+                                        </div>
+                                        <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
+                                            <input aria-label="Afficher le mot de passe" id="password-1758-show"
+                                                   type="checkbox"
+                                                   aria-describedby="password-1758-show-messages">
+                                            <label class="fr-password__checkbox fr-label" for="password-1758-show">
+                                                Afficher
+                                            </label>
+                                            <div class="fr-messages-group" id="password-1758-show-messages"
+                                                 aria-live="assertive">
+                                            </div>
+                                        </div>
+                                        <p>
+                                            <a href="{% url 'password_reset' %}" class="fr-link">
+                                                Mot de passe oublié ?
+                                            </a>
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="fr-messages-group" id="credentials-messages" aria-live="assertive">
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="fr-fieldset__element">
+                            <div class="fr-checkbox-group fr-checkbox-group--sm">
+                                <input name="remember" id="remember-1759" type="checkbox"
+                                       aria-describedby="remember-1759-messages">
+                                <label class="fr-label" for="remember-1759">
+                                    Se souvenir de moi
+                                </label>
+                                <div class="fr-messages-group" id="remember-1759-messages" aria-live="assertive">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="fr-fieldset__element">
+                            <ul class="fr-btns-group">
+                                <li>
+                                    <button class="fr-mt-2v fr-btn">
+                                        Se connecter
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="fr-messages-group" id="login-1760-fieldset-messages" aria-live="assertive">
+                        </div>
+                    </fieldset>
+                </form>
+
+
+            </div>
+            {# /col #}
+        </div>
+        {# /row #}
+    </div>
+    {# /container #}
+{% endblock content %}
+

--- a/secretariat/urls.py
+++ b/secretariat/urls.py
@@ -1,8 +1,19 @@
-from django.urls import path
+from django.urls import include, path
 
 from secretariat import views
 
 urlpatterns = [
     path("", views.view_index, name="index"),
     path("accessibilite/", views.view_accessibilite, name="accessibilite"),
+    path("compte/", include("django.contrib.auth.urls")),
 ]
+
+# see https://docs.djangoproject.com/en/4.2/topics/auth/default/#using-the-views
+# compte/login/ [name='login']
+# compte/logout/ [name='logout']
+# compte/password_change/ [name='password_change']
+# compte/password_change/done/ [name='password_change_done']
+# compte/password_reset/ [name='password_reset']
+# compte/password_reset/done/ [name='password_reset_done']
+# compte/reset/<uidb64>/<token>/ [name='password_reset_confirm']
+# compte/reset/done/ [name='password_reset_complete']


### PR DESCRIPTION
## 🎯 Objectif

Permettre aux usager·e·s de se connecter, de se déconnecter et de créer des comptes.

## 🔍 Implémentation

- utilisation des urls fournies par django
- mise en place du premier template pour le login

## ⚠️ Informations supplémentaires

Il y a pas mal de travail encore, et c'est possible que ce soit du travail "jetable" si on passe sur de l'authentification tierce (authentification/agent connect).

- [ ] gestion d'erreur dans le formulaire de login
- [ ] formulaire de création de compte
- [ ] gestion du logout
- [ ] (facultatif) mdp oublié

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

![Capture d’écran 2023-06-12 à 14 26 28](https://github.com/betagouv/operateur-secretariat/assets/1035145/5c3ab944-3604-4801-9173-1a4ba676dfb5)


