### PR TITLE
Fix - suppression d'un espace insécable dans un yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
           isort . --check --profile black --filter-files
       - name: Run the unit tests
         env:
-          OUTLINE_API_URL: ${{ secrets.OUTLINE_API_URL }}
+          OUTLINE_API_URL: ${{ secrets.OUTLINE_API_URL }}
           OUTLINE_API_TOKEN: ${{ secrets.OUTLINE_API_TOKEN }}
         run: |
           python manage.py test


### PR DESCRIPTION
## 🎯 Objectif

En ouvrant mon IDE, j'ai vu un espace insécable dans un yaml :

<img width="460" alt="Capture d’écran 2023-10-16 à 16 12 47" src="https://github.com/numerique-gouv/secretariat/assets/1035145/33d5e2e4-a3b0-432f-8037-88f5104a1b15">

J'ai supposé que ça n'allait pas aider les tests à tourner, je le remplace par un espace normal.
