### PR TITLE
Changement de la manière de vérifier l'absence d'uuid outline

### DIFF
--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -19,7 +19,7 @@ class UserAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
 
-        if obj.outline_uuid is None:
+        if not obj.outline_uuid:
             from secretariat.utils.outline import Client as OutlineClient
             from secretariat.utils.outline import InvitationFailed
 


### PR DESCRIPTION
## 🎯 Objectif

Marie a constaté que maintenant l'admin "invite tout le temps les gens sur outline".

Je me demande si on ne pourrait pas éviter ça en assouplissant le test : plutôt que de vérifier si le outline_uuid est None, on vérifie juste si c'est "falsy", donc à peu près vide (je soupçonne que ce soit une chaîne vide et que ce soit ça qui pose problème).

## 🔍 Implémentation

- _Une liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran, si pertinent_

