### PR TITLE
Invite to outline only when mail changes

### DIFF
--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -19,7 +19,7 @@ class UserAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
 
-        if obj.outline_uuid is None:
+        if "email" in form.changed_data:
             from secretariat.utils.outline import Client as OutlineClient
             from secretariat.utils.outline import InvitationFailed
 

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -19,7 +19,7 @@ class UserAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
 
-        if "email" in form.changed_data:
+        if obj.outline_uuid is None and "email" in form.changed_data:
             from secretariat.utils.outline import Client as OutlineClient
             from secretariat.utils.outline import InvitationFailed
 
@@ -31,6 +31,8 @@ class UserAdmin(admin.ModelAdmin):
                 client.add_to_outline_group(
                     user_uuid=obj.outline_uuid, group=OUTLINE_OPI_GROUP_ID
                 )
+                success_message = f"Mail « {obj.email} » invitée sur Outline et ajoutée au groupe Opérateur."
+                messages.success(request, success_message)
             except InvitationFailed:
                 error_message = f"L’invitation à Outline a échoué. Vérifiez que l'adresse email « {obj.email} » n'est pas déjà invitée sur Outline."
                 messages.warning(request, error_message)

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -31,7 +31,7 @@ class UserAdmin(admin.ModelAdmin):
                 client.add_to_outline_group(
                     user_uuid=obj.outline_uuid, group=OUTLINE_OPI_GROUP_ID
                 )
-                success_message = f"Mail « {obj.email} » invitée sur Outline et ajoutée au groupe Opérateur."
+                success_message = f"L'adresse email « {obj.email} » invitée sur Outline et ajoutée au groupe Opérateur."
                 messages.success(request, success_message)
             except InvitationFailed:
                 error_message = f"L’invitation à Outline a échoué. Vérifiez que l'adresse email « {obj.email} » n'est pas déjà invitée sur Outline."


### PR DESCRIPTION
## 🎯 Objectif

Présentement, sauvegarder dans l'admin déclenche l'invitation sur Outline, même quand on sauvegarde sans avoir rien changé.

Je veux que l'invitation ne se déclenche que quand l'email a été changé.

## 🔍 Implémentation

- _Une liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran, si pertinent_

