### PR TITLE
Admin - améliorations cosmétiques

### DIFF
--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -16,6 +16,26 @@ class UserAdmin(admin.ModelAdmin):
         "is_outline_synchronized",
     )
     readonly_fields = ["outline_uuid"]
+    fieldsets = (
+        (
+            "Utilisateur/rice",
+            {
+                "fields": ("username", "password", "email", "first_name", "last_name"),
+            },
+        ),
+        (
+            "Synchronisation",
+            {
+                "fields": ("outline_uuid", "date_joined"),
+            },
+        ),
+        (
+            "Django",
+            {
+                "fields": ("is_active", "is_staff", "is_superuser"),
+            },
+        ),
+    )
 
     @admin.display(description="Synchro Outline", boolean=True)
     def is_outline_synchronized(self, obj):

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -41,8 +41,12 @@ class UserAdmin(admin.ModelAdmin):
     def is_outline_synchronized(self, obj):
         return obj.outline_uuid is not None
 
-    def save_model(self, request, obj, form, change):
+    def save_model(self, request, obj: User, form, change):
         super().save_model(request, obj, form, change)
+
+        if "password" in form.changed_data:
+            obj.set_password(form.data["password"])
+            obj.save()
 
         if obj.outline_uuid is None and "email" in form.changed_data:
             from secretariat.utils.outline import Client as OutlineClient

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -13,8 +13,13 @@ class UserAdmin(admin.ModelAdmin):
         "last_name",
         "is_active",
         "is_staff",
+        "is_outline_synchronized",
     )
     readonly_fields = ["outline_uuid"]
+
+    @admin.display(description="Synchro Outline", boolean=True)
+    def is_outline_synchronized(self, obj):
+        return obj.outline_uuid is not None
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)


### PR DESCRIPTION
## 🎯 Objectif

Améliorer l'expérience utilisateur de l'admin Django qui va aller créer/modifier des usagers

## 🔍 Implémentation

- Modif de l'affichage de la liste pour ajouter l'état de synchronisation vers Outline
- Modif de l'affichage d'un formulaire à l'aide de l'option `fieldsets`
- Possibilité de donner un mot de passe utilisable depuis l'admin, en appelant la méthode `user.set_password()`


## 🖼️ Images

Vue liste : 

![Screenshot 2023-10-18 at 16-29-06 Select user to change Django site admin](https://github.com/numerique-gouv/secretariat/assets/1035145/44364a91-c9be-4b1e-93b1-275a02374245)

Vue utilisateur : 


![Screenshot 2023-10-18 at 16-28-54 test-nouveau-mail@corelka fr Change user Django site admin](https://github.com/numerique-gouv/secretariat/assets/1035145/d2248e5c-02fc-43d5-9d2b-0beba96d6c75)


