### PR TITLE
Filtrer par statut de synchro outline dans l'admin

### DIFF
--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -14,6 +14,24 @@ class MembershipInlineForOrganisation(MembershipInline):
     verbose_name_plural = "Membres"
 
 
+class SynchronizedWithOutlineFilter(admin.SimpleListFilter):
+    title = "Synchronisé avec Outline"
+    parameter_name = "outline_sync"
+    field_name = "outline_uuid"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("oui", "Oui"),
+            ("non", "Non"),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "oui":
+            return queryset.filter(**{f"{self.field_name}__isnull": False})
+        if self.value() == "non":
+            return queryset.filter(**{f"{self.field_name}__isnull": True})
+
+
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     list_display = (
@@ -25,6 +43,7 @@ class UserAdmin(admin.ModelAdmin):
         "is_staff",
         "is_outline_synchronized",
     )
+    list_filter = (SynchronizedWithOutlineFilter,)
     inlines = [MembershipInline]
     readonly_fields = ["outline_uuid"]
     fieldsets = (
@@ -85,21 +104,9 @@ def sync_organisations_with_outline(_, request, queryset):
             )
 
 
-class OrganisationSynchronizedWithOutlineFilter(admin.SimpleListFilter):
-    title = "Synchronisé avec Outline"
-    parameter_name = "outline_sync"
-
-    def lookups(self, request, model_admin):
-        return (
-            ("oui", "Oui"),
-            ("non", "Non"),
-        )
-
-    def queryset(self, request, queryset):
-        if self.value() == "oui":
-            return queryset.filter(outline_group_uuid__isnull=False)
-        if self.value() == "non":
-            return queryset.filter(outline_group_uuid__isnull=True)
+class OrganisationSynchronizedWithOutlineFilter(SynchronizedWithOutlineFilter):
+    title = "Synchronisée avec Outline"
+    field_name = "outline_group_uuid"
 
 
 @admin.register(Organisation)

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -85,10 +85,28 @@ def sync_organisations_with_outline(_, request, queryset):
             )
 
 
+class OrganisationSynchronizedWithOutlineFilter(admin.SimpleListFilter):
+    title = "Synchronisé avec Outline"
+    parameter_name = "outline_sync"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("oui", "Oui"),
+            ("non", "Non"),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "oui":
+            return queryset.filter(outline_group_uuid__isnull=False)
+        if self.value() == "non":
+            return queryset.filter(outline_group_uuid__isnull=True)
+
+
 @admin.register(Organisation)
 class OrganisationAdmin(admin.ModelAdmin):
     inlines = [MembershipInlineForOrganisation]
     actions = (sync_organisations_with_outline,)
+    list_filter = (OrganisationSynchronizedWithOutlineFilter,)
     list_display = (
         "name",
         "is_outline_synchronized",

--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -89,3 +89,11 @@ def sync_organisations_with_outline(_, request, queryset):
 class OrganisationAdmin(admin.ModelAdmin):
     inlines = [MembershipInlineForOrganisation]
     actions = (sync_organisations_with_outline,)
+    list_display = (
+        "name",
+        "is_outline_synchronized",
+    )
+
+    @admin.display(description="Synchro Outline", boolean=True)
+    def is_outline_synchronized(self, obj):
+        return obj.outline_group_uuid is not None

--- a/secretariat/tests/factories.py
+++ b/secretariat/tests/factories.py
@@ -17,6 +17,10 @@ class UserFactory(DjangoModelFactory):
     password = Faker("password")
 
 
+class UserSynchronizedWithOutlineFactory(UserFactory):
+    outline_uuid = Faker("uuid4")
+
+
 class OrganisationFactory(DjangoModelFactory):
     class Meta:
         model = models.Organisation

--- a/secretariat/tests/factories.py
+++ b/secretariat/tests/factories.py
@@ -24,6 +24,10 @@ class OrganisationFactory(DjangoModelFactory):
     name = Faker("company", locale="fr_FR")
 
 
+class OrganisationSynchronizedWithOutlineFactory(OrganisationFactory):
+    outline_group_uuid = Faker("uuid4")
+
+
 class MembershipFactory(DjangoModelFactory):
     class Meta:
         model = models.Membership

--- a/secretariat/tests/test_admin.py
+++ b/secretariat/tests/test_admin.py
@@ -3,17 +3,21 @@ from django.test import TestCase, tag
 from secretariat.admin import (
     OrganisationAdmin,
     OrganisationSynchronizedWithOutlineFilter,
+    SynchronizedWithOutlineFilter,
+    UserAdmin,
 )
-from secretariat.models import Organisation
+from secretariat.models import Organisation, User
 from secretariat.tests.factories import (
     OrganisationFactory,
     OrganisationSynchronizedWithOutlineFactory,
+    UserFactory,
+    UserSynchronizedWithOutlineFactory,
 )
 
 
 @tag("admin")
 class OutlineSyncFilterTests(TestCase):
-    def test_queryset(self):
+    def test_queryset_organisations(self):
         OrganisationFactory()
         OrganisationFactory()
         synced_org = OrganisationSynchronizedWithOutlineFactory()
@@ -43,3 +47,32 @@ class OutlineSyncFilterTests(TestCase):
         )
         self.assertEqual(2, queryset_unsynchronized.count())
         self.assertIsNone(queryset_unsynchronized[0].outline_group_uuid)
+
+    def test_queryset_users(self):
+        UserFactory()
+        UserFactory()
+        synced_user = UserSynchronizedWithOutlineFactory()
+        synchronized_filter = SynchronizedWithOutlineFilter(
+            None,
+            {"outline_sync": "oui"},
+            User,
+            UserAdmin,
+        )
+        queryset_synchronized = synchronized_filter.queryset(None, User.objects.all())
+        self.assertEqual(1, queryset_synchronized.count())
+        self.assertEqual(
+            str(synced_user.outline_uuid),
+            str(queryset_synchronized[0].outline_uuid),
+        )
+
+        unsynchronized_filter = SynchronizedWithOutlineFilter(
+            None,
+            {"outline_sync": "non"},
+            Organisation,
+            OrganisationAdmin,
+        )
+        queryset_unsynchronized = unsynchronized_filter.queryset(
+            None, User.objects.all()
+        )
+        self.assertEqual(2, queryset_unsynchronized.count())
+        self.assertIsNone(queryset_unsynchronized[0].outline_uuid)

--- a/secretariat/tests/test_admin.py
+++ b/secretariat/tests/test_admin.py
@@ -1,0 +1,45 @@
+from django.test import TestCase, tag
+
+from secretariat.admin import (
+    OrganisationAdmin,
+    OrganisationSynchronizedWithOutlineFilter,
+)
+from secretariat.models import Organisation
+from secretariat.tests.factories import (
+    OrganisationFactory,
+    OrganisationSynchronizedWithOutlineFactory,
+)
+
+
+@tag("admin")
+class OutlineSyncFilterTests(TestCase):
+    def test_queryset(self):
+        OrganisationFactory()
+        OrganisationFactory()
+        synced_org = OrganisationSynchronizedWithOutlineFactory()
+        synchronized_filter = OrganisationSynchronizedWithOutlineFilter(
+            None,
+            {"outline_sync": "oui"},
+            Organisation,
+            OrganisationAdmin,
+        )
+        queryset_synchronized = synchronized_filter.queryset(
+            None, Organisation.objects.all()
+        )
+        self.assertEqual(1, queryset_synchronized.count())
+        self.assertEqual(
+            str(synced_org.outline_group_uuid),
+            str(queryset_synchronized[0].outline_group_uuid),
+        )
+
+        unsynchronized_filter = OrganisationSynchronizedWithOutlineFilter(
+            None,
+            {"outline_sync": "non"},
+            Organisation,
+            OrganisationAdmin,
+        )
+        queryset_unsynchronized = unsynchronized_filter.queryset(
+            None, Organisation.objects.all()
+        )
+        self.assertEqual(2, queryset_unsynchronized.count())
+        self.assertIsNone(queryset_unsynchronized[0].outline_group_uuid)


### PR DESCRIPTION
## 🎯 Objectif

Permettre de détecter et synchroniser rapidement les organisations django qui nécessitent une synchronisation vers un groupe outline

## 🔍 Implémentation

- Ajout d'une colonne dans admin list display pour les organisations
- création d'un filtre basé sur `SimpleListFilter` pour filtrer les `User` et les `Organisation`. Petite difficulté car on ne filtre pas les éléments "utilisateurs" et "organisation" via le même champ en BDD.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

Tous les groupes : on voit la colonne "synchro outline" qui dit oui ou non
<img width="1105" alt="tableau montrant tous les groupes" src="https://github.com/numerique-gouv/secretariat/assets/1035145/324bd7bf-833d-45ce-9dd9-6d94175f38a1">

Activation de l'un ou l'autre des filtres (d'abord oui puis non) : on voit que seuls les groupes pertinents sont affichés.
<img width="1103" alt="groupes synchronisés" src="https://github.com/numerique-gouv/secretariat/assets/1035145/d80ea33a-b219-4269-a254-202308d45eda">
<img width="1105" alt="groupes non synchronisés" src="https://github.com/numerique-gouv/secretariat/assets/1035145/8a39fb16-e3ed-4f18-bf05-f8efee18521e">


