### PR TITLE
Harmonisation de la synchro outline des usagers et des organisations

### DIFF
--- a/secretariat/admin.py
+++ b/secretariat/admin.py
@@ -100,15 +100,6 @@ class UserAdmin(admin.ModelAdmin):
             obj.set_password(form.data["password"])
             obj.save()
 
-        if obj.outline_uuid is None and "email" in form.changed_data:
-            try:
-                obj.synchronize_to_outline()
-                success_message = f"L'adresse email « {obj.email} » a été invitée sur Outline et ajoutée au(x) groupe(s) adéquat(s)."
-                messages.success(request, success_message)
-            except Exception:
-                error_message = f"L’invitation à Outline a échoué. Vérifiez que l'adresse email « {obj.email} » n'est pas déjà invitée sur Outline."
-                messages.warning(request, error_message)
-
 
 class OrganisationSynchronizedWithOutlineFilter(SynchronizedWithOutlineFilter):
     title = "Synchronisée avec Outline"

--- a/secretariat/models.py
+++ b/secretariat/models.py
@@ -5,6 +5,10 @@ from django.db.models import CheckConstraint, F, Q
 
 
 class User(AbstractUser):
+    class Meta:
+        verbose_name = "estimé·e collègue"
+        verbose_name_plural = "estimé·e·s collègues"
+
     outline_uuid = models.UUIDField(null=True, blank=True, default=None)
 
     def __str__(self):


### PR DESCRIPTION
## 🎯 Objectif

Ainsi que nous l'avons évoqué sur le mattermost de manière moins élégante, il y a un souci d'UX pour la synchro outline dans l'admin : on la lance manuellement pour les orga et elle est parfois lancée de manière automatique pour les usagers, sans possibilité de la lancer manuellement.

On harmonise l'expérience : pour les deux, ce sera de la synchro manuelle. Combiné avec les filtres de la PR précédente, ce sera parfait.

## 🔍 Implémentation

- Utilisation d'une seule action admin pour les deux classes d'objets, pour éviter le copier-coller de code.

## 🖼️ Images

Regardez ces merveilleux messages d'erreur sans duplication de code !

<img width="1359" alt="Capture d’écran 2023-12-05 à 11 18 52" src="https://github.com/numerique-gouv/secretariat/assets/1035145/fd6fbe70-17ad-4c5d-b11f-1c9975dde765">
<img width="1209" alt="Capture d’écran 2023-12-05 à 11 18 27" src="https://github.com/numerique-gouv/secretariat/assets/1035145/5bcaa030-88c1-4c01-8f91-4286e8971d68">

