### PR TITLE
Synchroniser un utilisateur l'enlève des collections auxquels il n'a pas accès

### DIFF
--- a/secretariat/models.py
+++ b/secretariat/models.py
@@ -37,6 +37,17 @@ class User(AbstractUser):
             if group.outline_group_uuid:
                 client.add_to_outline_group(self.outline_uuid, group.outline_group_uuid)
 
+        # remove users from outline group which are not in django orga
+        outline_memberships = set(
+            membership["groupId"] for membership in client.list_user_memberships(self)
+        )
+        user_organisation = set(
+            organisation.outline_group_uuid for organisation in self.organisations
+        )
+
+        for outline_group_uuid in outline_memberships - user_organisation:
+            client.remove_from_outline_group(self.outline_uuid, outline_group_uuid)
+
 
 class Organisation(models.Model):
     name = models.CharField(max_length=70)

--- a/secretariat/models.py
+++ b/secretariat/models.py
@@ -38,6 +38,9 @@ class User(AbstractUser):
                 client.add_to_outline_group(self.outline_uuid, group.outline_group_uuid)
 
         # remove users from outline group which are not in django orga
+        self._remove_user_from_unauthorized_groups(client)
+
+    def _remove_user_from_unauthorized_groups(self, client):
         outline_memberships = set(
             membership["groupId"] for membership in client.list_user_memberships(self)
         )

--- a/secretariat/tests/test_user_synchronization.py
+++ b/secretariat/tests/test_user_synchronization.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from config.settings import OUTLINE_API_TOKEN, OUTLINE_URL
 from secretariat.models import User
-from secretariat.tests.factories import UserFactory
+from secretariat.tests.factories import UserFactory, OrganisationFactory, MembershipFactory
 from secretariat.utils.outline import Client as OutlineClient
 
 
@@ -80,3 +80,29 @@ class TestUserSynchronization(TestCase):
             thibaut.email,
             "User should have the same email in django and outline",
         )
+
+    def test_removing_user_from_organisation_should_removes_them_on_outline(self):
+        """
+
+        """
+        user = UserFactory()
+        user.outline_uuid = self.outline_client.invite_to_outline(user)
+        orga = OrganisationFactory()
+        orga.outline_group_uuid = self.outline_client.create_new_group(orga.name)
+        membership = MembershipFactory(user=user, organisation=orga)
+        self.outline_client.add_to_outline_group(user.outline_uuid, orga.outline_group_uuid)
+
+        outline_memberships = self.outline_client.list_user_memberships(user)
+        self.assertTrue(
+            next((True for elem in outline_memberships if orga.outline_group_uuid in elem['groupId']), False), 
+            "User should be listed in newly created group.",)
+
+        membership.delete()
+        user.synchronize_to_outline()
+
+        self.assertFalse(
+            next((True for elem in outline_memberships if orga.outline_group_uuid in elem['groupId']), False), 
+            "User should not be listed in any group.",)
+
+        self.outline_client.remove_user_from_outline(user)
+        self.outline_client.delete_group_from_outline(orga)

--- a/secretariat/utils/outline.py
+++ b/secretariat/utils/outline.py
@@ -212,12 +212,12 @@ class Client:
         )
 
     def list_user_memberships(self, user):
-        # in absence of api endpoint to list user memberships, 
+        # in absence of api endpoint to list user memberships,
         # we have to check user presence in all groups
 
         user_groups = []
 
-        for group in self.list_groups(): 
+        for group in self.list_groups():
             response = requests.post(
                 url=f"{self.api_url}/groups.memberships",
                 headers=self.headers,
@@ -227,11 +227,11 @@ class Client:
                     "sort": "createdAt",
                     "direction": "ASC",
                     "id": str(group["id"]),
-                    "query": str(user.first_name)
+                    "query": str(user.first_name),
                 },
             )
-            groupMemberships = response.json().get("data").get("groupMemberships")
-            if groupMemberships != []:
-                user_groups.append(groupMemberships)
+            group_memberships = response.json().get("data").get("group_memberships")
+            if group_memberships != []:
+                user_groups.append(group_memberships)
 
         return [membership for group in user_groups for membership in group]

--- a/secretariat/utils/outline.py
+++ b/secretariat/utils/outline.py
@@ -230,8 +230,11 @@ class Client:
                     "query": str(user.first_name),
                 },
             )
-            group_memberships = response.json().get("data").get("group_memberships")
+            group_memberships = response.json().get("data").get("groupMemberships")
             if group_memberships != []:
                 user_groups.append(group_memberships)
 
-        return [membership for group in user_groups for membership in group]
+        memberships_flat_list = [
+            membership for group in user_groups for membership in group
+        ]
+        return memberships_flat_list

--- a/secretariat/utils/outline.py
+++ b/secretariat/utils/outline.py
@@ -210,3 +210,28 @@ class Client:
                 "id": str(group.outline_group_uuid),
             },
         )
+
+    def list_user_memberships(self, user):
+        # in absence of api endpoint to list user memberships, 
+        # we have to check user presence in all groups
+
+        user_groups = []
+
+        for group in self.list_groups(): 
+            response = requests.post(
+                url=f"{self.api_url}/groups.memberships",
+                headers=self.headers,
+                json={
+                    "offset": 0,
+                    "limit": 100,
+                    "sort": "createdAt",
+                    "direction": "ASC",
+                    "id": str(group["id"]),
+                    "query": str(user.first_name)
+                },
+            )
+            groupMemberships = response.json().get("data").get("groupMemberships")
+            if groupMemberships != []:
+                user_groups.append(groupMemberships)
+
+        return [membership for group in user_groups for membership in group]


### PR DESCRIPTION
## 🎯 Objectif

Faire en sorte que la synchronisation vérifie les appartenances aux groupes (qui eux-même gèrent les accès aux collections).

## 🔍 Implémentation

- [x] le test qui va bien
- [x] récupérer un diff éventuel entre outline et django et supprimer l'user des groupes auxquels iel n'est pas censé appartenir

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran, si pertinent_

